### PR TITLE
Compress productive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "memo_wise"
 gem "productive"
 
 group :development do
+  gem "rake"
   gem "standard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     public_suffix (4.0.6)
     rack (2.2.3)
     rainbow (3.0.0)
+    rake (13.0.6)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -87,6 +88,7 @@ DEPENDENCIES
   dotenv
   memo_wise
   productive
+  rake
   rspec
   standard
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,40 @@
+require "dotenv"
+Dotenv.load
+
+require_relative "./lib/event/event"
+require_relative "./lib/event/event_collection"
+require_relative "./lib/productive_client"
+
+namespace :productive do
+  desc "Compress all compressible managed events on Productive"
+  task :compress, [:dry_run] do |t, args|
+    args.with_defaults(dry_run: true)
+
+    ProductiveClient.configure(
+      account_id: ENV.fetch("PRODUCTIVE_ACCOUNT_ID"),
+      api_key: ENV.fetch("PRODUCTIVE_API_KEY"),
+      event_ids: {
+        holiday: ENV.fetch("PRODUCTIVE_HOLIDAY_EVENT_ID")
+      },
+      dry_run: args[:dry_run]
+    )
+
+    productive_events = ProductiveClient.events(
+      after: Date.new(2019, 7, 1)
+    )
+
+    productive_events.each_pair { |email, events|
+      puts "#{email}: finding changes"
+
+      changeset = events.all_changes_from(
+        events,
+        compress: true,
+        split_half_days: true
+      )
+
+      ProductiveClient.update_events_for(email, changeset)
+
+      puts "#{email}: done"
+    }
+  end
+end

--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -7,8 +7,9 @@ class EventCollection
     @events = events.sort_by(&:start_date)
   end
 
-  def all_changes_from(other, compress: false)
+  def all_changes_from(other, compress: false, split_half_days: false)
     our = compress ? self.compress : self
+    our = split_half_days ? our.split_half_days : our
 
     our_unshared_events = our.events.reject { |event|
       other.events.include?(event)
@@ -18,10 +19,13 @@ class EventCollection
     }
 
     added = self.class.new(our_unshared_events)
+    added = compress ? added.compress : added
+    added = split_half_days ? added.split_half_days : added
+
     removed = self.class.new(their_unshared_events)
 
     {
-      added: compress ? added.compress : added,
+      added: added,
       removed: removed
     }
   end
@@ -41,6 +45,58 @@ class EventCollection
       .sort_by(&:start_date)
 
     self.class.new(compressed_events)
+  end
+
+  def split_half_days
+    split_events = events
+      .map { |event|
+        next event unless event.start_half_day || event.end_half_day
+        next event if event.start_date == event.end_date
+
+        splits = []
+        full_time_start_date = event.start_date
+        full_time_end_date = event.end_date
+
+        if event.start_half_day
+          splits << Event.new(
+            type: event.type,
+            start_date: event.start_date,
+            end_date: event.start_date,
+            start_half_day: true,
+            end_half_day: true
+          )
+
+          full_time_start_date = event.start_date + 1
+        end
+
+        if event.end_half_day
+          splits << Event.new(
+            type: event.type,
+            start_date: event.end_date,
+            end_date: event.end_date,
+            start_half_day: true,
+            end_half_day: true
+          )
+
+          full_time_end_date = event.end_date - 1
+        end
+
+        if full_time_start_date < full_time_end_date
+          splits << Event.new(
+            type: event.type,
+            start_date: full_time_start_date,
+            end_date: full_time_end_date,
+            start_half_day: false,
+            end_half_day: false
+          )
+        end
+
+        splits.uniq
+      }
+      .flatten
+      .sort_by(&:start_date)
+
+    self.class.new(split_events)
   end
 
   private

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -249,4 +249,113 @@ RSpec.describe EventCollection do
       expect(collection.events).to be(events)
     end
   end
+
+  describe "#split_half_days" do
+    it "returns a new collection with all half day events split from full day events" do
+      holiday_starting_with_half_day = Event.new(
+        type: :holiday,
+        start_date: Date.new(2000, 1, 1),
+        end_date: Date.new(2000, 2, 2),
+        start_half_day: true
+      )
+      holiday_ending_with_half_day = Event.new(
+        type: :holiday,
+        start_date: Date.new(2001, 1, 1),
+        end_date: Date.new(2001, 2, 2),
+        end_half_day: true
+      )
+      holiday_with_both_half_days = Event.new(
+        type: :holiday,
+        start_date: Date.new(2002, 1, 1),
+        end_date: Date.new(2002, 2, 2),
+        start_half_day: true,
+        end_half_day: true
+      )
+      holiday_with_no_half_days = Event.new(
+        type: :holiday,
+        start_date: Date.new(2003, 1, 1),
+        end_date: Date.new(2003, 2, 2)
+      )
+
+      collection = EventCollection.new([
+        holiday_starting_with_half_day,
+        holiday_ending_with_half_day,
+        holiday_with_both_half_days,
+        holiday_with_no_half_days
+      ])
+
+      result = collection.split_half_days
+
+      expect(result.events).to eq([
+        # holiday_starting_with_half_day
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2000, 1, 1),
+          end_date: Date.new(2000, 1, 1),
+          start_half_day: true,
+          end_half_day: true
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2000, 1, 2),
+          end_date: Date.new(2000, 2, 2)
+        ),
+
+        # holiday_ending_with_half_day
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2001, 1, 1),
+          end_date: Date.new(2001, 2, 1)
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2001, 2, 2),
+          end_date: Date.new(2001, 2, 2),
+          start_half_day: true,
+          end_half_day: true
+        ),
+
+        # holiday_with_both_half_days
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2002, 1, 1),
+          end_date: Date.new(2002, 1, 1),
+          start_half_day: true,
+          end_half_day: true
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2002, 1, 2),
+          end_date: Date.new(2002, 2, 1)
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2002, 2, 2),
+          end_date: Date.new(2002, 2, 2),
+          start_half_day: true,
+          end_half_day: true
+        ),
+
+        holiday_with_no_half_days
+      ])
+    end
+
+    it "doesn't modify the events of the original" do
+      holiday_with_both_half_days = Event.new(
+        type: :holiday,
+        start_date: Date.new(2002, 1, 1),
+        end_date: Date.new(2002, 2, 2),
+        start_half_day: true,
+        end_half_day: true
+      )
+
+      collection = EventCollection.new([holiday_with_both_half_days])
+
+      events = collection.events
+
+      collection.split_half_days
+
+      expect(collection.events).to be(events)
+    end
+  end
 end

--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -8,7 +8,9 @@ class ProductiveClient
 
     DEFAULT_WORKING_HOURS = 7
 
-    def configure(account_id:, api_key:, event_ids:)
+    attr_reader :dry_run
+
+    def configure(account_id:, api_key:, event_ids:, dry_run: true)
       reset_memo_wise
 
       Productive.configure do |config|
@@ -17,6 +19,7 @@ class ProductiveClient
       end
 
       @event_ids = event_ids
+      @dry_run = dry_run
     end
 
     def events(after:)


### PR DESCRIPTION
Compress Productive holiday events as a Rake task. Doing this is mostly a demonstration of how this project works. When we have integrations with other systems, they should make this defunct by doing the compression themselves.