### PR TITLE
Set the sickness event ID from the environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ namespace :productive do
       api_key: ENV.fetch("PRODUCTIVE_API_KEY"),
       event_ids: {
         holiday: ENV.fetch("PRODUCTIVE_HOLIDAY_EVENT_ID"),
+        sickness: ENV.fetch("PRODUCTIVE_SICKNESS_EVENT_ID"),
         other_leave: ENV.fetch("PRODUCTIVE_OTHER_LEAVE_EVENT_ID")
       },
       dry_run: dry_run
@@ -87,6 +88,7 @@ namespace :breathe do
       api_key: ENV.fetch("PRODUCTIVE_API_KEY"),
       event_ids: {
         holiday: ENV.fetch("PRODUCTIVE_HOLIDAY_EVENT_ID"),
+        sickness: ENV.fetch("PRODUCTIVE_SICKNESS_EVENT_ID"),
         other_leave: ENV.fetch("PRODUCTIVE_OTHER_LEAVE_EVENT_ID")
       },
       dry_run: dry_run


### PR DESCRIPTION
Without this, we don't know which Productive event type to create, causing errors when attempting to sync sickness.