### PR TITLE
Handle half-full-half shaped events correctly

### DIFF
--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -81,7 +81,7 @@ class EventCollection
           full_time_end_date = event.end_date - 1
         end
 
-        if full_time_start_date < full_time_end_date
+        if full_time_start_date <= full_time_end_date
           splits << Event.new(
             type: event.type,
             start_date: full_time_start_date,

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -276,12 +276,28 @@ RSpec.describe EventCollection do
         start_date: Date.new(2003, 1, 1),
         end_date: Date.new(2003, 2, 2)
       )
+      holiday_with_adjacent_half_days = Event.new(
+        type: :holiday,
+        start_date: Date.new(2004, 1, 1),
+        end_date: Date.new(2004, 1, 2),
+        start_half_day: true,
+        end_half_day: true
+      )
+      holiday_with_one_full_day_and_two_half_days = Event.new(
+        type: :holiday,
+        start_date: Date.new(2005, 1, 1),
+        end_date: Date.new(2005, 1, 3),
+        start_half_day: true,
+        end_half_day: true
+      )
 
       collection = EventCollection.new([
         holiday_starting_with_half_day,
         holiday_ending_with_half_day,
         holiday_with_both_half_days,
-        holiday_with_no_half_days
+        holiday_with_no_half_days,
+        holiday_with_adjacent_half_days,
+        holiday_with_one_full_day_and_two_half_days
       ])
 
       result = collection.split_half_days
@@ -336,7 +352,44 @@ RSpec.describe EventCollection do
           end_half_day: true
         ),
 
-        holiday_with_no_half_days
+        holiday_with_no_half_days,
+
+        # holiday_with_adjacent_half_days
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2004, 1, 1),
+          end_date: Date.new(2004, 1, 1),
+          start_half_day: true,
+          end_half_day: true
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2004, 1, 2),
+          end_date: Date.new(2004, 1, 2),
+          start_half_day: true,
+          end_half_day: true
+        ),
+
+        # holiday_with_one_full_day_and_two_half_days
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2005, 1, 1),
+          end_date: Date.new(2005, 1, 1),
+          start_half_day: true,
+          end_half_day: true
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2005, 1, 2),
+          end_date: Date.new(2005, 1, 2)
+        ),
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2005, 1, 3),
+          end_date: Date.new(2005, 1, 3),
+          start_half_day: true,
+          end_half_day: true
+        )
       ])
     end
 


### PR DESCRIPTION
When we split an event which starts with a half-day on day 1, has a full day 2, and ends with another half-day on day 3, we should end up with 3 events: one for each day. However, we were incorrectly skipping the middle full day. This fixes that.