### PR TITLE
Only process the last 90 days and the future

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ namespace :productive do
     )
 
     productive_events = ProductiveClient.events(
-      after: Date.new(2019, 7, 1)
+      after: Date.today - 90
     )
 
     productive_events.each_pair { |email, events|
@@ -94,7 +94,7 @@ namespace :breathe do
       dry_run: dry_run
     )
 
-    date = Date.new(2019, 7, 1)
+    date = Date.today - 90
 
     breathe_events = BreatheClient.events(
       after: date


### PR DESCRIPTION
Fetching data from all time is slow and wasteful. It's very uncommon for events to change further in the past than 90 days ago, and any changes that do happen can be handled separately (perhaps with an "all" or "since" subtask?).