### PR TITLE
Only mark events as adjacent when they have adjacent half-days

### DIFF
--- a/lib/event/event.rb
+++ b/lib/event/event.rb
@@ -36,14 +36,29 @@ class Event
   end
 
   def adjacent_to?(other)
+    ends_at_other_start_same_day =
+      end_date == other.start_date &&
+      end_half_day &&
+      other.start_half_day
+    ends_at_other_start_different_day =
+      end_date + 1 == other.start_date &&
+      !end_half_day &&
+      !other.start_half_day
     ends_at_other_start =
-      end_date + 1 == other.start_date || (
-        end_date == other.start_date && end_half_day && other.start_half_day
-      )
+      ends_at_other_start_same_day ||
+      ends_at_other_start_different_day
+
+    other_ends_at_start_same_day =
+      other.end_date == start_date &&
+      other.end_half_day &&
+      start_half_day
+    other_ends_at_start_different_day =
+      other.end_date + 1 == start_date &&
+      !other.end_half_day &&
+      !start_half_day
     other_ends_at_start =
-      other.end_date + 1 == start_date || (
-        other.end_date == start_date && other.end_half_day && start_half_day
-      )
+      other_ends_at_start_same_day ||
+      other_ends_at_start_different_day
 
     ends_at_other_start || other_ends_at_start
   end

--- a/lib/event/event_spec.rb
+++ b/lib/event/event_spec.rb
@@ -250,6 +250,30 @@ RSpec.describe Event do
         expectation: true
       },
       {
+        name: "returns false when the other event starts (PM) on the day after the end (PM) of the subject",
+        other: {
+          start_date: subject_end_date + 1,
+          end_date: subject_end_date + 30,
+          start_half_day: true
+        },
+        subject: {
+          end_half_day: false
+        },
+        expectation: false
+      },
+      {
+        name: "returns false when the other event starts (PM) on the day after the end (AM) of the subject",
+        other: {
+          start_date: subject_end_date + 1,
+          end_date: subject_end_date + 30,
+          start_half_day: true
+        },
+        subject: {
+          end_half_day: true
+        },
+        expectation: false
+      },
+      {
         name: "returns true when the other event ends (PM) on the day before the start (AM) of the subject",
         other: {
           start_date: subject_start_date - 30,
@@ -260,6 +284,30 @@ RSpec.describe Event do
           start_half_day: false
         },
         expectation: true
+      },
+      {
+        name: "returns false when the other event ends (AM) on the day before the start (AM) of the subject",
+        other: {
+          start_date: subject_start_date - 30,
+          end_date: subject_start_date - 1,
+          end_half_day: true
+        },
+        subject: {
+          start_half_day: false
+        },
+        expectation: false
+      },
+      {
+        name: "returns false when the other event ends (AM) on the day before the start (PM) of the subject",
+        other: {
+          start_date: subject_start_date - 30,
+          end_date: subject_start_date - 1,
+          end_half_day: true
+        },
+        subject: {
+          start_half_day: true
+        },
+        expectation: false
       },
 
       # same day


### PR DESCRIPTION
Consider the following events:

- 1 - 3 (AM only)
- 4 - 9

These events aren't adjacent because there is a half day gap between the end of the first and the start of the second. However our code was treating them as adjacent prior to this change.