### PR TITLE
Use half_day_at_{start,end} instead of {start,end}_half_day

### DIFF
--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -52,15 +52,15 @@ class BreatheClient
 
             start_date = absence.start_date.to_date
             end_date = absence.end_date.to_date
-            start_half_day = absence.half_start
-            end_half_day = absence.half_end
+            half_day_at_start = absence.half_start
+            half_day_at_end = absence.half_end
 
             Event.new(
               type: type,
               start_date: start_date,
               end_date: end_date,
-              start_half_day: start_half_day,
-              end_half_day: end_half_day
+              half_day_at_start: half_day_at_start,
+              half_day_at_end: half_day_at_end
             )
           }
           .compact
@@ -83,15 +83,15 @@ class BreatheClient
           .map { |sickness|
             start_date = sickness[:start_date].to_date
             end_date = sickness[:end_date]&.to_date || Date.today
-            start_half_day = sickness[:half_start]
-            end_half_day = sickness[:half_end]
+            half_day_at_start = sickness[:half_start]
+            half_day_at_end = sickness[:half_end]
 
             Event.new(
               type: :sickness,
               start_date: start_date,
               end_date: end_date,
-              start_half_day: start_half_day,
-              end_half_day: end_half_day
+              half_day_at_start: half_day_at_start,
+              half_day_at_end: half_day_at_end
             )
           }
           .compact
@@ -120,15 +120,15 @@ class BreatheClient
 
             next if end_date.nil?
 
-            start_half_day = training[:half_start]
-            end_half_day = training[:half_end]
+            half_day_at_start = training[:half_start]
+            half_day_at_end = training[:half_end]
 
             Event.new(
               type: :other_leave,
               start_date: start_date,
               end_date: end_date,
-              start_half_day: start_half_day,
-              end_half_day: end_half_day
+              half_day_at_start: half_day_at_start,
+              half_day_at_end: half_day_at_end
             )
           }
           .compact

--- a/lib/event/event.rb
+++ b/lib/event/event.rb
@@ -7,14 +7,20 @@ class Event
     :other_leave
   ].freeze
 
-  attr_reader :type, :start_date, :end_date, :start_half_day, :end_half_day
+  attr_reader(
+    :type,
+    :start_date,
+    :end_date,
+    :half_day_at_start,
+    :half_day_at_end
+  )
 
   def initialize(
     type:,
     start_date:,
     end_date:,
-    start_half_day: false,
-    end_half_day: false
+    half_day_at_start: false,
+    half_day_at_end: false
   )
     raise "#{type} is not a recognized event type" unless TYPES.include?(type)
     raise "#{start_date} is not a date" unless start_date.is_a?(Date)
@@ -27,8 +33,8 @@ class Event
     @type = type
     @start_date = start_date
     @end_date = end_date
-    @start_half_day = start_half_day
-    @end_half_day = end_half_day
+    @half_day_at_start = half_day_at_start
+    @half_day_at_end = half_day_at_end
   end
 
   def matches_type?(other)
@@ -38,24 +44,24 @@ class Event
   def adjacent_to?(other)
     ends_at_other_start_same_day =
       end_date == other.start_date &&
-      end_half_day &&
-      other.start_half_day
+      half_day_at_end &&
+      other.half_day_at_start
     ends_at_other_start_different_day =
       end_date + 1 == other.start_date &&
-      !end_half_day &&
-      !other.start_half_day
+      !half_day_at_end &&
+      !other.half_day_at_start
     ends_at_other_start =
       ends_at_other_start_same_day ||
       ends_at_other_start_different_day
 
     other_ends_at_start_same_day =
       other.end_date == start_date &&
-      other.end_half_day &&
-      start_half_day
+      other.half_day_at_end &&
+      half_day_at_start
     other_ends_at_start_different_day =
       other.end_date + 1 == start_date &&
-      !other.end_half_day &&
-      !start_half_day
+      !other.half_day_at_end &&
+      !half_day_at_start
     other_ends_at_start =
       other_ends_at_start_same_day ||
       other_ends_at_start_different_day
@@ -67,8 +73,8 @@ class Event
     starts_days_before = start_date < other.start_date
     starts_earlier_on_day =
       start_date == other.start_date &&
-      !start_half_day &&
-      other.start_half_day
+      !half_day_at_start &&
+      other.half_day_at_start
 
     starts_days_before || starts_earlier_on_day
   end
@@ -77,8 +83,8 @@ class Event
     ends_days_after = end_date > other.end_date
     ends_later_on_day =
       end_date == other.end_date &&
-      !end_half_day &&
-      other.end_half_day
+      !half_day_at_end &&
+      other.half_day_at_end
 
     ends_days_after || ends_later_on_day
   end
@@ -88,15 +94,15 @@ class Event
     matches_start_day =
       other.start_date == start_date &&
       (
-        other.start_half_day == start_half_day ||
-        (!start_half_day && other.start_half_day)
+        other.half_day_at_start == half_day_at_start ||
+        (!half_day_at_start && other.half_day_at_start)
       ) &&
       ends_after?(other)
     matches_end_day =
       other.end_date == end_date &&
       (
-        other.end_half_day == end_half_day ||
-        (!end_half_day && other.end_half_day)
+        other.half_day_at_end == half_day_at_end ||
+        (!half_day_at_end && other.half_day_at_end)
       ) &&
       starts_before?(other)
 
@@ -109,8 +115,8 @@ class Event
       (
         other.start_date == end_date &&
         (
-          !end_half_day ||
-          (end_half_day && !other.start_half_day)
+          !half_day_at_end ||
+          (half_day_at_end && !other.half_day_at_start)
         )
       )
     starts_during_other =
@@ -118,8 +124,8 @@ class Event
       (
         start_date == other.end_date &&
         (
-          !other.end_half_day ||
-          (other.end_half_day && !start_half_day)
+          !other.half_day_at_end ||
+          (other.half_day_at_end && !half_day_at_start)
         )
       )
     prequel =
@@ -152,26 +158,26 @@ class Event
     return other if other.covers?(self)
 
     new_start_date = start_date
-    new_start_half_day = start_half_day
+    new_half_day_at_start = half_day_at_start
     new_end_date = end_date
-    new_end_half_day = end_half_day
+    new_half_day_at_end = half_day_at_end
 
     if other.starts_before?(self)
       new_start_date = other.start_date
-      new_start_half_day = other.start_half_day
+      new_half_day_at_start = other.half_day_at_start
     end
 
     if other.ends_after?(self)
       new_end_date = other.end_date
-      new_end_half_day = other.end_half_day
+      new_half_day_at_end = other.half_day_at_end
     end
 
     Event.new(
       type: type,
       start_date: new_start_date,
       end_date: new_end_date,
-      start_half_day: new_start_half_day,
-      end_half_day: new_end_half_day
+      half_day_at_start: new_half_day_at_start,
+      half_day_at_end: new_half_day_at_end
     )
   end
 
@@ -179,7 +185,7 @@ class Event
     other.type == type &&
       other.start_date == start_date &&
       other.end_date == end_date &&
-      other.start_half_day == start_half_day &&
-      other.end_half_day == end_half_day
+      other.half_day_at_start == half_day_at_start &&
+      other.half_day_at_end == half_day_at_end
   end
 end

--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -50,32 +50,32 @@ class EventCollection
   def split_half_days
     split_events = events
       .map { |event|
-        next event unless event.start_half_day || event.end_half_day
+        next event unless event.half_day_at_start || event.half_day_at_end
         next event if event.start_date == event.end_date
 
         splits = []
         full_time_start_date = event.start_date
         full_time_end_date = event.end_date
 
-        if event.start_half_day
+        if event.half_day_at_start
           splits << Event.new(
             type: event.type,
             start_date: event.start_date,
             end_date: event.start_date,
-            start_half_day: true,
-            end_half_day: true
+            half_day_at_start: true,
+            half_day_at_end: true
           )
 
           full_time_start_date = event.start_date + 1
         end
 
-        if event.end_half_day
+        if event.half_day_at_end
           splits << Event.new(
             type: event.type,
             start_date: event.end_date,
             end_date: event.end_date,
-            start_half_day: true,
-            end_half_day: true
+            half_day_at_start: true,
+            half_day_at_end: true
           )
 
           full_time_end_date = event.end_date - 1
@@ -86,8 +86,8 @@ class EventCollection
             type: event.type,
             start_date: full_time_start_date,
             end_date: full_time_end_date,
-            start_half_day: false,
-            end_half_day: false
+            half_day_at_start: false,
+            half_day_at_end: false
           )
         end
 

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe EventCollection do
         type: :holiday,
         start_date: Date.new(2000, 1, 1),
         end_date: Date.new(2000, 2, 1),
-        start_half_day: true
+        half_day_at_start: true
       )
     }
     let(:theirs_b) {
@@ -68,7 +68,7 @@ RSpec.describe EventCollection do
         type: :sickness,
         start_date: Date.new(2000, 1, 1),
         end_date: Date.new(2000, 2, 1),
-        end_half_day: true
+        half_day_at_end: true
       )
     }
     let(:theirs_c) {
@@ -256,20 +256,20 @@ RSpec.describe EventCollection do
         type: :holiday,
         start_date: Date.new(2000, 1, 1),
         end_date: Date.new(2000, 2, 2),
-        start_half_day: true
+        half_day_at_start: true
       )
       holiday_ending_with_half_day = Event.new(
         type: :holiday,
         start_date: Date.new(2001, 1, 1),
         end_date: Date.new(2001, 2, 2),
-        end_half_day: true
+        half_day_at_end: true
       )
       holiday_with_both_half_days = Event.new(
         type: :holiday,
         start_date: Date.new(2002, 1, 1),
         end_date: Date.new(2002, 2, 2),
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
       holiday_with_no_half_days = Event.new(
         type: :holiday,
@@ -280,15 +280,15 @@ RSpec.describe EventCollection do
         type: :holiday,
         start_date: Date.new(2004, 1, 1),
         end_date: Date.new(2004, 1, 2),
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
       holiday_with_one_full_day_and_two_half_days = Event.new(
         type: :holiday,
         start_date: Date.new(2005, 1, 1),
         end_date: Date.new(2005, 1, 3),
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
 
       collection = EventCollection.new([
@@ -308,8 +308,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2000, 1, 1),
           end_date: Date.new(2000, 1, 1),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
         Event.new(
           type: :holiday,
@@ -327,8 +327,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2001, 2, 2),
           end_date: Date.new(2001, 2, 2),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
 
         # holiday_with_both_half_days
@@ -336,8 +336,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2002, 1, 1),
           end_date: Date.new(2002, 1, 1),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
         Event.new(
           type: :holiday,
@@ -348,8 +348,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2002, 2, 2),
           end_date: Date.new(2002, 2, 2),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
 
         holiday_with_no_half_days,
@@ -359,15 +359,15 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2004, 1, 1),
           end_date: Date.new(2004, 1, 1),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
         Event.new(
           type: :holiday,
           start_date: Date.new(2004, 1, 2),
           end_date: Date.new(2004, 1, 2),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
 
         # holiday_with_one_full_day_and_two_half_days
@@ -375,8 +375,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2005, 1, 1),
           end_date: Date.new(2005, 1, 1),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         ),
         Event.new(
           type: :holiday,
@@ -387,8 +387,8 @@ RSpec.describe EventCollection do
           type: :holiday,
           start_date: Date.new(2005, 1, 3),
           end_date: Date.new(2005, 1, 3),
-          start_half_day: true,
-          end_half_day: true
+          half_day_at_start: true,
+          half_day_at_end: true
         )
       ])
     end
@@ -398,8 +398,8 @@ RSpec.describe EventCollection do
         type: :holiday,
         start_date: Date.new(2002, 1, 1),
         end_date: Date.new(2002, 2, 2),
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
 
       collection = EventCollection.new([holiday_with_both_half_days])

--- a/lib/event/event_spec.rb
+++ b/lib/event/event_spec.rb
@@ -113,16 +113,16 @@ RSpec.describe Event do
     end
   end
 
-  describe "#start_half_day" do
+  describe "#half_day_at_start" do
     it "returns the initial start half day" do
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true
+        half_day_at_start: true
       )
 
-      expect(event.start_half_day).to be(true)
+      expect(event.half_day_at_start).to be(true)
     end
 
     it "defaults to false" do
@@ -132,7 +132,7 @@ RSpec.describe Event do
         end_date: end_date
       )
 
-      expect(event.start_half_day).to be(false)
+      expect(event.half_day_at_start).to be(false)
     end
 
     it "is read-only" do
@@ -140,23 +140,23 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true
+        half_day_at_start: true
       )
 
-      expect(event).not_to respond_to(:start_half_day=)
+      expect(event).not_to respond_to(:half_day_at_start=)
     end
   end
 
-  describe "#end_half_day" do
+  describe "#half_day_at_end" do
     it "returns the initial end half day" do
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        end_half_day: true
+        half_day_at_end: true
       )
 
-      expect(event.end_half_day).to be(true)
+      expect(event.half_day_at_end).to be(true)
     end
 
     it "defaults to false" do
@@ -166,7 +166,7 @@ RSpec.describe Event do
         end_date: end_date
       )
 
-      expect(event.end_half_day).to be(false)
+      expect(event.half_day_at_end).to be(false)
     end
 
     it "is read-only" do
@@ -174,10 +174,10 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        end_half_day: true
+        half_day_at_end: true
       )
 
-      expect(event).not_to respond_to(:end_half_day=)
+      expect(event).not_to respond_to(:half_day_at_end=)
     end
   end
 
@@ -242,10 +242,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_end_date + 1,
           end_date: subject_end_date + 30,
-          start_half_day: false
+          half_day_at_start: false
         },
         subject: {
-          end_half_day: false
+          half_day_at_end: false
         },
         expectation: true
       },
@@ -254,10 +254,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_end_date + 1,
           end_date: subject_end_date + 30,
-          start_half_day: true
+          half_day_at_start: true
         },
         subject: {
-          end_half_day: false
+          half_day_at_end: false
         },
         expectation: false
       },
@@ -266,10 +266,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_end_date + 1,
           end_date: subject_end_date + 30,
-          start_half_day: true
+          half_day_at_start: true
         },
         subject: {
-          end_half_day: true
+          half_day_at_end: true
         },
         expectation: false
       },
@@ -278,10 +278,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_start_date - 30,
           end_date: subject_start_date - 1,
-          end_half_day: false
+          half_day_at_end: false
         },
         subject: {
-          start_half_day: false
+          half_day_at_start: false
         },
         expectation: true
       },
@@ -290,10 +290,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_start_date - 30,
           end_date: subject_start_date - 1,
-          end_half_day: true
+          half_day_at_end: true
         },
         subject: {
-          start_half_day: false
+          half_day_at_start: false
         },
         expectation: false
       },
@@ -302,10 +302,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_start_date - 30,
           end_date: subject_start_date - 1,
-          end_half_day: true
+          half_day_at_end: true
         },
         subject: {
-          start_half_day: true
+          half_day_at_start: true
         },
         expectation: false
       },
@@ -316,10 +316,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_end_date,
           end_date: subject_end_date + 30,
-          start_half_day: true
+          half_day_at_start: true
         },
         subject: {
-          end_half_day: true
+          half_day_at_end: true
         },
         expectation: true
       },
@@ -328,10 +328,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_start_date - 30,
           end_date: subject_start_date,
-          end_half_day: true
+          half_day_at_end: true
         },
         subject: {
-          start_half_day: true
+          half_day_at_start: true
         },
         expectation: true
       },
@@ -342,10 +342,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_end_date,
           end_date: subject_end_date + 30,
-          start_half_day: false
+          half_day_at_start: false
         },
         subject: {
-          end_half_day: false
+          half_day_at_end: false
         },
         expectation: false
       },
@@ -354,10 +354,10 @@ RSpec.describe Event do
         other: {
           start_date: subject_start_date - 30,
           end_date: subject_start_date,
-          end_half_day: false
+          half_day_at_end: false
         },
         subject: {
-          start_half_day: false
+          half_day_at_start: false
         },
         expectation: false
       },
@@ -403,15 +403,15 @@ RSpec.describe Event do
           type: :holiday,
           start_date: test_case[:other][:start_date],
           end_date: test_case[:other][:end_date],
-          start_half_day: test_case[:other][:start_half_day],
-          end_half_day: test_case[:other][:end_half_day]
+          half_day_at_start: test_case[:other][:half_day_at_start],
+          half_day_at_end: test_case[:other][:half_day_at_end]
         )
         event = Event.new(
           type: :holiday,
           start_date: subject_start_date,
           end_date: subject_end_date,
-          start_half_day: test_case.fetch(:subject, {})[:start_half_day],
-          end_half_day: test_case.fetch(:subject, {})[:end_half_day]
+          half_day_at_start: test_case.fetch(:subject, {})[:half_day_at_start],
+          half_day_at_end: test_case.fetch(:subject, {})[:half_day_at_end]
         )
 
         expect(event.adjacent_to?(other)).to be(test_case[:expectation])
@@ -440,13 +440,13 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date + 30,
-        start_half_day: true
+        half_day_at_start: true
       )
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: false
+        half_day_at_start: false
       )
 
       expect(event.starts_before?(other)).to be(true)
@@ -457,13 +457,13 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date + 30,
-        start_half_day: false
+        half_day_at_start: false
       )
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true
+        half_day_at_start: true
       )
 
       expect(event.starts_before?(other)).to be(false)
@@ -506,13 +506,13 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date - 30,
         end_date: end_date,
-        end_half_day: true
+        half_day_at_end: true
       )
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        end_half_day: false
+        half_day_at_end: false
       )
 
       expect(event.ends_after?(other)).to be(true)
@@ -523,13 +523,13 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date - 30,
         end_date: end_date,
-        end_half_day: false
+        half_day_at_end: false
       )
       event = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        end_half_day: true
+        half_day_at_end: true
       )
 
       expect(event.ends_after?(other)).to be(false)
@@ -849,30 +849,30 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true
+        half_day_at_start: true
       )
       before = Event.new(
         type: :holiday,
         start_date: start_date - 3,
         end_date: end_date,
-        start_half_day: false
+        half_day_at_start: false
       )
       after = Event.new(
         type: :holiday,
         start_date: start_date + 3,
         end_date: end_date,
-        start_half_day: false
+        half_day_at_start: false
       )
 
       new_before = event.merge_with(before)
 
       expect(new_before.start_date).to eq(start_date - 3)
-      expect(new_before.start_half_day).to be(false)
+      expect(new_before.half_day_at_start).to be(false)
 
       new_after = event.merge_with(after)
 
       expect(new_after.start_date).to eq(start_date)
-      expect(new_after.start_half_day).to be(true)
+      expect(new_after.half_day_at_start).to be(true)
     end
 
     it "returns a new event with the latest end date and matching end half day" do
@@ -880,30 +880,30 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        end_half_day: true
+        half_day_at_end: true
       )
       before = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date - 3,
-        end_half_day: false
+        half_day_at_end: false
       )
       after = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date + 3,
-        end_half_day: false
+        half_day_at_end: false
       )
 
       new_before = event.merge_with(before)
 
       expect(new_before.end_date).to eq(end_date)
-      expect(new_before.end_half_day).to be(true)
+      expect(new_before.half_day_at_end).to be(true)
 
       new_after = event.merge_with(after)
 
       expect(new_after.end_date).to eq(end_date + 3)
-      expect(new_after.end_half_day).to be(false)
+      expect(new_after.half_day_at_end).to be(false)
     end
   end
 
@@ -913,15 +913,15 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
       other = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
 
       expect(event == other).to be(true)
@@ -932,15 +932,15 @@ RSpec.describe Event do
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: true,
-        end_half_day: true
+        half_day_at_start: true,
+        half_day_at_end: true
       )
       other = Event.new(
         type: :holiday,
         start_date: start_date,
         end_date: end_date,
-        start_half_day: false,
-        end_half_day: false
+        half_day_at_start: false,
+        half_day_at_end: false
       )
 
       expect(event == other).to be(false)

--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -70,8 +70,8 @@ class ProductiveClient
               type: event_ids.key(booking.event.id),
               start_date: start_date,
               end_date: end_date,
-              start_half_day: half_day,
-              end_half_day: half_day
+              half_day_at_start: half_day,
+              half_day_at_end: half_day
             )
           }
           .compact
@@ -116,7 +116,7 @@ class ProductiveClient
         )
 
         time =
-          event.start_half_day || event.end_half_day ?
+          event.half_day_at_start || event.half_day_at_end ?
           working_time / 2 :
           working_time
 


### PR DESCRIPTION
This is hopefully clearer what they represent without needing extra context.