### PR TITLE
Drop support for compressing events alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,3 @@ Note that this is a destructive operation. It works by looking at the current
 state of the managed events in BreatheHR and updates Productive to match them by
 removing any existing events in Productive that don't exist in BreatheHR, and
 creating new events when they exist in BreatheHR but not Productive.
-
-### Extra functionality
-
-#### Simplify / compress events on Productive
-
-```
-$ bundle exec rake productive:compress
-```
-
-You're unlikely to need to run this as it's included as part of the sync tasks,
-but if you want to unify existing neighbouring events without synchronising with
-other systems, this is how you do it.

--- a/Rakefile
+++ b/Rakefile
@@ -14,44 +14,7 @@ def to_bool(arg)
 end
 
 namespace :productive do
-  desc "Compress all compressible managed events on Productive"
-  task :compress, [:dry_run] do |t, args|
-    args.with_defaults(dry_run: true)
-
-    dry_run = to_bool(args[:dry_run])
-
-    puts "Doing a dry run!" if dry_run
-
-    ProductiveClient.configure(
-      account_id: ENV.fetch("PRODUCTIVE_ACCOUNT_ID"),
-      api_key: ENV.fetch("PRODUCTIVE_API_KEY"),
-      event_ids: {
-        holiday: ENV.fetch("PRODUCTIVE_HOLIDAY_EVENT_ID"),
-        sickness: ENV.fetch("PRODUCTIVE_SICKNESS_EVENT_ID"),
-        other_leave: ENV.fetch("PRODUCTIVE_OTHER_LEAVE_EVENT_ID")
-      },
-      dry_run: dry_run
-    )
-
-    productive_events = ProductiveClient.events(
-      after: Date.today - 90
-    )
-
-    productive_events.each_pair { |email, events|
-      puts "#{email}: finding changes"
-
-      changeset = events.all_changes_from(
-        events,
-        compress: true,
-        split_half_days: true
-      )
-
-      ProductiveClient.update_events_for(email, changeset)
-
-      puts "#{email}: done"
-    }
-  end
-
+  desc "List all event types on Productive"
   task :list_event_types do
     ProductiveClient.configure(
       account_id: ENV.fetch("PRODUCTIVE_ACCOUNT_ID"),


### PR DESCRIPTION
It's a maintenance burden and isn't useful as it's run as part of the sync.