### PR TITLE
Email aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ PRODUCTIVE_API_KEY=
 PRODUCTIVE_HOLIDAY_EVENT_ID=43368
 PRODUCTIVE_SICKNESS_EVENT_ID=46970
 PRODUCTIVE_OTHER_LEAVE_EVENT_ID=45434
+
+# Use this to specify a list of email aliases that represent the same person.
+# Each line is a single person with a comma separated list of email addresses.
+EMAIL_ALIASES="
+person@dxw.com, nickname@dxw.com
+other-person@dxw.com, other-nickname@dxw.com
+"

--- a/README.md
+++ b/README.md
@@ -28,15 +28,3 @@ Note that this is a destructive operation. It works by looking at the current
 state of the managed events in BreatheHR and updates Productive to match them by
 removing any existing events in Productive that don't exist in BreatheHR, and
 creating new events when they exist in BreatheHR but not Productive.
-
-### Extra functionality
-
-#### Simplify / compress events on Productive
-
-```
-$ bundle exec rake productive:compress
-```
-
-You're unlikely to need to run this as it's included as part of the sync tasks,
-but if you want to unify existing neighbouring events without synchronising with
-other systems, this is how you do it.

--- a/Rakefile
+++ b/Rakefile
@@ -14,44 +14,7 @@ def to_bool(arg)
 end
 
 namespace :productive do
-  desc "Compress all compressible managed events on Productive"
-  task :compress, [:dry_run] do |t, args|
-    args.with_defaults(dry_run: true)
-
-    dry_run = to_bool(args[:dry_run])
-
-    puts "Doing a dry run!" if dry_run
-
-    ProductiveClient.configure(
-      account_id: ENV.fetch("PRODUCTIVE_ACCOUNT_ID"),
-      api_key: ENV.fetch("PRODUCTIVE_API_KEY"),
-      event_ids: {
-        holiday: ENV.fetch("PRODUCTIVE_HOLIDAY_EVENT_ID"),
-        sickness: ENV.fetch("PRODUCTIVE_SICKNESS_EVENT_ID"),
-        other_leave: ENV.fetch("PRODUCTIVE_OTHER_LEAVE_EVENT_ID")
-      },
-      dry_run: dry_run
-    )
-
-    productive_events = ProductiveClient.events(
-      after: Date.today - 90
-    )
-
-    productive_events.each_pair { |email, events|
-      puts "#{email}: finding changes"
-
-      changeset = events.all_changes_from(
-        events,
-        compress: true,
-        split_half_days: true
-      )
-
-      ProductiveClient.update_events_for(email, changeset)
-
-      puts "#{email}: done"
-    }
-  end
-
+  desc "List all event types on Productive"
   task :list_event_types do
     ProductiveClient.configure(
       account_id: ENV.fetch("PRODUCTIVE_ACCOUNT_ID"),

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ Dotenv.load
 
 require_relative "./lib/event/event"
 require_relative "./lib/event/event_collection"
+require_relative "./lib/person/person"
 require_relative "./lib/breathe_client"
 require_relative "./lib/productive_client"
 
@@ -59,33 +60,8 @@ namespace :breathe do
 
     date = Date.today - 90
 
-    breathe_events = BreatheClient.events(
-      after: date
-    )
-
-    productive_events = ProductiveClient.events(
-      after: date
-    )
-
-    breathe_events.each_pair { |email, events|
-      other_events = productive_events[email]
-
-      if other_events.nil?
-        puts "#{email}: no match"
-        next
-      end
-
-      puts "#{email}: finding changes"
-
-      changeset = events.all_changes_from(
-        other_events,
-        compress: true,
-        split_half_days: true
-      )
-
-      ProductiveClient.update_events_for(email, changeset)
-
-      puts "#{email}: done"
-    }
+    Person
+      .all_from_breathe
+      .each { |person| person.sync_breathe_to_productive(after: date) }
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,13 @@ def to_bool(arg)
   raise ArgumentError.new("Unable to convert value to boolean: \"#{arg}\"")
 end
 
+def email_aliases
+  ENV.fetch("EMAIL_ALIASES", "")
+    .strip
+    .split("\n")
+    .map { |line| line.strip.split(/\s*[,;]\s*/) }
+end
+
 namespace :productive do
   desc "List all event types on Productive"
   task :list_event_types do
@@ -44,7 +51,8 @@ namespace :breathe do
       },
       event_reason_types: {
         ignored: ENV.fetch("BREATHE_IGNORED_EVENT_REASON_TYPES").split(",")
-      }
+      },
+      email_aliases: email_aliases
     )
 
     ProductiveClient.configure(

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -6,12 +6,13 @@ class BreatheClient
   class << self
     prepend MemoWise
 
-    def configure(api_key:, event_types:, event_reason_types:)
+    def configure(api_key:, event_types:, event_reason_types:, email_aliases:)
       reset_memo_wise
 
       @client = Breathe::Client.new(api_key: api_key, auto_paginate: true)
       @event_types = event_types
       @event_reason_types = event_reason_types
+      @email_aliases = email_aliases
     end
 
     def events(person:, after:)
@@ -125,7 +126,7 @@ class BreatheClient
 
     SECONDS_FOR_RATE_LIMIT_RESET = 60
 
-    attr_reader :client, :event_types, :event_reason_types
+    attr_reader :client, :event_types, :event_reason_types, :email_aliases
 
     def absences(employee_id:, after:)
       client

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -159,8 +159,7 @@ class BreatheClient
           exclude_cancelled_sicknesses: true
         )
         .response
-        .data
-        .to_h[:sicknesses]
+        .data[:sicknesses]
     end
     memo_wise :sicknesses
 
@@ -172,8 +171,7 @@ class BreatheClient
           exclude_cancelled_employee_training_courses: true
         )
         .response
-        .data
-        .to_h[:employee_training_courses]
+        .data[:employee_training_courses]
     end
     memo_wise :trainings
 

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -185,8 +185,13 @@ class BreatheClient
     memo_wise :trainings
 
     def rate_limited?(error)
-      error.instance_of?(Breathe::UnknownError) &&
+      (
+        error.instance_of?(Breathe::UnknownError) &&
         client.last_response.data[:error][:type] == "Rate Limit Reached"
+      ) || (
+        error.instance_of?(TypeError) &&
+        error.message == "no implicit conversion of nil into Array"
+      )
     end
 
     def await_rate_limit_reset

--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -99,6 +99,10 @@ class EventCollection
     self.class.new(split_events)
   end
 
+  def +(other)
+    self.class.new(events + other.events)
+  end
+
   private
 
   attr_writer :events

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -9,22 +9,25 @@ class Person
           id = employee[:id]
           email = employee[:email]
 
-          Person.new(email: email, breathe_id: id)
+          emails = email_aliases.find { |emails| emails.include?(email) }
+          emails = [email] if emails.nil?
+
+          Person.new(emails: emails, breathe_id: id)
         }
         .compact
     end
   end
 
-  attr_reader :email, :breathe_id, :productive_id
+  attr_reader :emails, :breathe_id, :productive_id
 
-  def initialize(email:, breathe_id: nil, productive_id: nil)
-    @email = email
+  def initialize(emails:, breathe_id: nil, productive_id: nil)
+    @emails = emails
     @breathe_id = breathe_id
     @productive_id = productive_id
   end
 
   def label
-    email
+    emails.first
   end
 
   def sync_breathe_to_productive(after:)
@@ -56,7 +59,7 @@ class Person
   def fetch_productive_attributes
     return true unless productive_id.nil?
 
-    productive_person = ProductiveClient.person(email: email)
+    productive_person = ProductiveClient.person(emails: emails)
 
     return false if productive_person.nil?
 

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -1,0 +1,75 @@
+require_relative "../breathe_client"
+require_relative "../productive_client"
+
+class Person
+  class << self
+    def all_from_breathe
+      BreatheClient.employees
+        .map { |employee|
+          id = employee[:id]
+          email = employee[:email]
+
+          Person.new(email: email, breathe_id: id)
+        }
+        .compact
+    end
+  end
+
+  attr_reader :email, :breathe_id, :productive_id
+
+  def initialize(email:, breathe_id: nil, productive_id: nil)
+    @email = email
+    @breathe_id = breathe_id
+    @productive_id = productive_id
+  end
+
+  def label
+    email
+  end
+
+  def sync_breathe_to_productive(after:)
+    unless fetch_productive_attributes
+      puts "#{label}: no match on Productive"
+      return
+    end
+
+    puts "#{label}: finding changes"
+
+    breathe_events = breathe_events(after: after)
+    productive_events = productive_events(after: after)
+
+    changeset = breathe_events.all_changes_from(
+      productive_events,
+      compress: true,
+      split_half_days: true
+    )
+
+    ProductiveClient.update_events_for(self, changeset)
+
+    puts "#{label}: done"
+  end
+
+  private
+
+  attr_writer :breathe_id, :productive_id
+
+  def fetch_productive_attributes
+    return true unless productive_id.nil?
+
+    productive_person = ProductiveClient.person(email: email)
+
+    return false if productive_person.nil?
+
+    self.productive_id = productive_person.id
+
+    true
+  end
+
+  def breathe_events(after:)
+    BreatheClient.events(person: self, after: after)
+  end
+
+  def productive_events(after:)
+    ProductiveClient.events(person: self, after: after)
+  end
+end

--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -124,8 +124,8 @@ class ProductiveClient
       }
     end
 
-    def person(email:)
-      Productive::Person.where(email: email).first
+    def person(emails:)
+      Productive::Person.where(email: emails).first
     end
     memo_wise :person
 


### PR DESCRIPTION
Relies on #26 due to API changes here breaking the compression task.

There are two main changes in this PR:

1. Switch to syncing person by person instead of by fetching all the events and grouping for processing
2. Support email aliases to match users up between systems

Please see the commit messages for more details.