### PR TITLE
Fetch data from breathe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.bundle/
 /vendor/bundle/
 .env
+/tmp/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -46,3 +46,20 @@ Running the tests:
 ```
 $ bundle exec rspec lib
 ```
+
+## Debugging
+
+Sometimes the synchronisation can go wrong, and we need to investigate why.
+Very few people have API access to BreatheHR, and those people tend to have very
+little time. In order to make the most out of their limited time, we have a task
+that makes it easier to export the data from BreatheHR, so whoever is debugging the
+app can request it from a person with access and continue working without them.
+
+The task takes as optional arguments a list of emails (separated with **semicolons**)
+and a date.
+
+Example usage:
+
+```
+$ bundle exec rake breathe:data_dump[emails:"example1@example.org;example2@example.org"]
+```

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ argument into the task.
 ```
 $ bundle exec rake 'breathe:to_productive[2020-01-01]'
 ```
+
+## Developing
+
+Running the tests:
+
+```
+$ bundle exec rspec lib
+```

--- a/Rakefile
+++ b/Rakefile
@@ -76,4 +76,30 @@ namespace :breathe do
       .all_from_breathe
       .each { |person| person.sync_breathe_to_productive(after: earliest_date) }
   end
+
+  desc "Obtain the data from breathe"
+  task :data_dump, [:earliest_date] do |t, args|
+    args.with_defaults(earliest_date: (Date.today - 90).strftime)
+
+    earliest_date = Date.parse(args[:earliest_date])
+    puts "Fetching events on or after #{earliest_date.strftime}"
+
+    BreatheClient.configure(
+      api_key: ENV.fetch("BREATHE_API_KEY"),
+      event_types: {
+        holiday: ENV.fetch("BREATHE_HOLIDAY_EVENT_TYPE"),
+        other_leave: ENV.fetch("BREATHE_OTHER_LEAVE_EVENT_TYPE")
+      },
+      event_reason_types: {
+        ignored: ENV.fetch("BREATHE_IGNORED_EVENT_REASON_TYPES").split(",")
+      },
+      email_aliases: email_aliases
+    )
+
+    from_breathe = Person
+      .all_from_breathe
+      .map { |person| person.breathe_events(after: earliest_date).as_json }
+
+    File.write("Events from breathe after #{earliest_date.strftime}.json", from_breathe)
+  end
 end

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -82,23 +82,30 @@ class BreatheClient
     def training_events(person:, after:)
       events = trainings(employee_id: person.breathe_id, after: after)
         .map { |training|
-          start_date = training[:start_date]&.to_date
+          start_date = training[:start_on]&.to_date
 
-          next if start_date.nil?
+          if start_date.nil?
+            puts "[DEBUG] Skipping training with nil start_date for #{person.breathe_id}"
+            next
+          end
 
-          end_date = training[:end_date]&.to_date
+          end_date = training[:end_on]&.to_date
 
-          next if end_date.nil?
+          if end_date.nil?
+            puts "[DEBUG] Skipping training with nil end_date for #{person.breathe_id}"
+            next
+          end
 
-          half_day_at_start = training[:half_start]
-          half_day_at_end = training[:half_end]
+          # TODO: Fix half day logic
+          # half_day_at_start = training[:half_start]
+          # half_day_at_end = training[:half_end]
 
           Event.new(
             type: :other_leave,
             start_date: start_date,
-            end_date: end_date,
-            half_day_at_start: half_day_at_start,
-            half_day_at_end: half_day_at_end
+            end_date: end_date
+            # half_day_at_start: half_day_at_start,
+            # half_day_at_end: half_day_at_end
           )
         }
         .compact

--- a/lib/event/event.rb
+++ b/lib/event/event.rb
@@ -188,4 +188,14 @@ class Event
       other.half_day_at_start == half_day_at_start &&
       other.half_day_at_end == half_day_at_end
   end
+
+  def as_json
+    {
+      "type" => type.to_s,
+      "start_date" => start_date.strftime("%F"),
+      "end_date" => end_date.strftime("%F"),
+      "half_day_at_start" => half_day_at_start,
+      "half_day_at_end" => half_day_at_end
+    }
+  end
 end

--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -80,6 +80,10 @@ class EventCollection
     self.class.new(events + other.events)
   end
 
+  def as_json
+    events.map(&:as_json)
+  end
+
   private
 
   attr_writer :events

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -284,4 +284,22 @@ RSpec.describe EventCollection do
       expect(collection.events).to be(events)
     end
   end
+
+  describe "#as_json" do
+    it "returns the events as json" do
+      first_event = Event.new(
+        type: :holiday,
+        start_date: Date.new(2000, 1, 1),
+        end_date: Date.new(2000, 2, 1)
+      )
+      second_event = Event.new(
+        type: :holiday,
+        start_date: Date.new(2000, 1, 10),
+        end_date: Date.new(2000, 1, 14)
+      )
+
+      collection = EventCollection.new([first_event, second_event])
+      expect(collection.as_json).to eql([first_event.as_json, second_event.as_json])
+    end
+  end
 end

--- a/lib/event/event_spec.rb
+++ b/lib/event/event_spec.rb
@@ -946,4 +946,23 @@ RSpec.describe Event do
       expect(event == other).to be(false)
     end
   end
+
+  describe "#as_json" do
+    it "returns the attributes ready to be JSONified" do
+      event = Event.new(
+        type: :holiday,
+        start_date: start_date,
+        end_date: end_date
+      )
+      expect(event.as_json).to eql(
+        {
+          "type" => "holiday",
+          "start_date" => start_date.strftime("%F"),
+          "end_date" => end_date.strftime("%F"),
+          "half_day_at_end" => false,
+          "half_day_at_start" => false
+        }
+      )
+    end
+  end
 end

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -51,8 +51,12 @@ class Person
     puts "#{label}: done"
   end
 
-  def breathe_events(after:)
-    BreatheClient.events(person: self, after: after)
+  def breathe_data(after:)
+    {
+      emails: emails,
+      earliest_date: after.strftime("%F"),
+      events: breathe_events(after: after).as_json
+    }
   end
 
   private
@@ -69,6 +73,10 @@ class Person
     self.productive_id = productive_person.id
 
     true
+  end
+
+  def breathe_events(after:)
+    BreatheClient.events(person: self, after: after)
   end
 
   def productive_events(after:)

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -51,6 +51,10 @@ class Person
     puts "#{label}: done"
   end
 
+  def breathe_events(after:)
+    BreatheClient.events(person: self, after: after)
+  end
+
   private
 
   attr_writer :breathe_id, :productive_id
@@ -65,10 +69,6 @@ class Person
     self.productive_id = productive_person.id
 
     true
-  end
-
-  def breathe_events(after:)
-    BreatheClient.events(person: self, after: after)
   end
 
   def productive_events(after:)


### PR DESCRIPTION
In order to diagnose potential issues when importing data from breatheHR we need the data that would be used by the integration script.
This script is meant to be run by someone with API access.
The person who is potentially debugging the script does not necessarily have API access, so therefore we need an easier way to transfer the data needed for debugging to the debugger.
This data is outputted into a new file for this reason.