### PR TITLE
Rake task to do a dry run syncing data from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,44 @@ $ bundle exec rspec lib
 
 Sometimes the synchronisation can go wrong, and we need to investigate why.
 Very few people have API access to BreatheHR, and those people tend to have very
-little time. In order to make the most out of their limited time, we have a task
-that makes it easier to export the data from BreatheHR, so whoever is debugging the
-app can request it from a person with access and continue working without them.
+little time. In order to make the most out of their limited time, we have a couple of
+tasks that make it easier to work with the data.
+
+### Exporting data from BreatheHR
+
+Also known as a data dump. This tasks exports the event data from BreatheHR, so whoever
+is debugging the app can request it from a person with access and work off the outputted
+files.
 
 The task takes as optional arguments a list of emails (separated with **semicolons**)
-and a date.
+and the earliest date to look up events from (`earliest_date`).
 
 Example usage:
 
 ```
 $ bundle exec rake breathe:data_dump[emails:"example1@example.org;example2@example.org"]
+```
+
+Note: for some shells, such as zsh, you might have to escape the square brackets, e.g.
+
+```
+$ bundle exec rake breathe:data_dump\[emails:"example1@example.org;example2@example.org"\]
+```
+
+If no emails are given, it will export data for all people records in Breathe, and if no
+starting date is given a default date will be used (currently 90 days before the current
+date).
+
+### Executing a dry run of synchronising data from files into Productive
+
+Requires:
+
+- Productive API credentials (read access is sufficient)
+- Data dumps in the format produced by the previous task to be present in the local folder
+`tmp/data/breathe/`
+
+Example usage:
+
+```
+$ bundle exec rake breathe:to_productive_from_dump
 ```

--- a/lib/event/event_collection.rb
+++ b/lib/event/event_collection.rb
@@ -1,6 +1,18 @@
 require_relative "./event"
 
 class EventCollection
+  def self.from_array(events_as_array)
+    EventCollection.new(events_as_array.map do |event|
+      Event.new(
+        type: event["type"].to_sym,
+        start_date: Date.parse(event["start_date"]),
+        end_date: Date.parse(event["end_date"]),
+        half_day_at_start: event["half_day_at_start"],
+        half_day_at_end: event["half_day_at_end"]
+      )
+    end)
+  end
+
   attr_reader :events
 
   def initialize(events)

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -3,6 +3,33 @@ require_relative "./event"
 require_relative "./event_collection"
 
 RSpec.describe EventCollection do
+  describe ".from_array" do
+    it "initalises an event collection" do
+      events_array = [
+        {
+          "type" => "holiday",
+          "start_date" => "2020-02-02",
+          "end_date" => "2020-03-01",
+          "half_day_at_start" => true,
+          "half_day_at_end" => true
+        }
+      ]
+
+      collection = EventCollection.from_array(events_array)
+
+      expect(collection).to be_a(EventCollection)
+      expect(collection.events).to eq([
+        Event.new(
+          type: :holiday,
+          start_date: Date.new(2020, 2, 2),
+          end_date: Date.new(2020, 3, 1),
+          half_day_at_start: true,
+          half_day_at_end: true
+        )
+      ])
+    end
+  end
+
   describe "#events" do
     it "returns the events, sorted by start date" do
       earliest = Event.new(

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -30,7 +30,7 @@ class Person
     emails.first
   end
 
-  def sync_breathe_to_productive(after:)
+  def sync_breathe_to_productive(after:, breathe_events: nil)
     unless fetch_productive_attributes
       puts "#{label}: no match on Productive"
       return
@@ -38,7 +38,7 @@ class Person
 
     puts "#{label}: finding changes"
 
-    breathe_events = breathe_events(after: after)
+    breathe_events = breathe_events(after: after) unless breathe_events
     productive_events = productive_events(after: after)
 
     changeset = {


### PR DESCRIPTION
In order to investigate issues with synchronising data from BreatheHR
into Productive, we’re adding a task to simulate a dry run using data
obtained from a data dump. This is so that we don’t need API access to
BreatheHR, as long as we have the data from someone with access.

Productive API access is less sensitive, and can be given to more team
members.