### PR TITLE
Fix half-day for training events

### DIFF
--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -96,16 +96,15 @@ class BreatheClient
             next
           end
 
-          # TODO: Fix half day logic
-          # half_day_at_start = training[:half_start]
-          # half_day_at_end = training[:half_end]
+          half_day_at_start = training[:half_day] && training[:half_day_am_pm].to_s.downcase == "am"
+          half_day_at_end = training[:half_day] && training[:half_day_am_pm].to_s.downcase == "pm"
 
           Event.new(
             type: :other_leave,
             start_date: start_date,
             end_date: end_date
-            # half_day_at_start: half_day_at_start,
-            # half_day_at_end: half_day_at_end
+            half_day_at_start: half_day_at_start,
+            half_day_at_end: half_day_at_end
           )
         }
         .compact


### PR DESCRIPTION
Training events use different attributes to specify half-day events:
- `half_day`, a boolean
- `half_day_am_pm`, which can be `nil`, `"am"`, or `"pm"`

There is, however, no way to specify what time of the day the training
takes place, so there is no way to detect that something is happening
outside working hours.