### PR TITLE
Fix: Add missing comma to fix breathe_client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,5 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rspec lib
+      - name: Run linting
+        run: bundle exec standardrb

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -102,7 +102,7 @@ class BreatheClient
           Event.new(
             type: :other_leave,
             start_date: start_date,
-            end_date: end_date
+            end_date: end_date,
             half_day_at_start: half_day_at_start,
             half_day_at_end: half_day_at_end
           )


### PR DESCRIPTION
This was missed as tests don't instantiate the client. We could have caught it if we had a linting step - which I've now added as part of this PR.