### PR TITLE
Fix rake task instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ Also known as a data dump. This tasks exports the event data from BreatheHR, so 
 is debugging the app can request it from a person with access and work off the outputted
 files.
 
-The task takes as optional arguments a list of emails (separated with **semicolons**)
-and the earliest date to look up events from (`earliest_date`).
+The task takes as arguments a list of emails (separated with **semicolons**)
+and (optionally) the earliest date to look up events from in YYYY-MM-DD format.
 
 Example usage:
 
 ```
-$ bundle exec rake breathe:data_dump[emails:"example1@example.org;example2@example.org"]
+$ bundle exec rake breathe:data_dump["example1@example.org;example2@example.org","2022-07-01"]
 ```
 
 Note: for some shells, such as zsh, you might have to escape the square brackets, e.g.
 
 ```
-$ bundle exec rake breathe:data_dump\[emails:"example1@example.org;example2@example.org"\]
+$ bundle exec rake breathe:data_dump\["example1@example.org;example2@example.org","2022-07-01"\]
 ```
 
 If no emails are given, it will export data for all people records in Breathe, and if no


### PR DESCRIPTION
There was a misunderstanding about sending arguments to a rake task. It
turns out that they don’t support keyword arguments after all, so the
task was incorrectly using `emails:` as part of the first email.

Since the arguments are positional, we can’t make both optional and have
them sent in whichever combination, so remove the “optional” from the
instructions.

The next fix will be to enforce the presence of emails.