### PR TITLE
Don’t pin setup-ruby to specific minor version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1.139.0
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Run tests


### PR DESCRIPTION
From setup-ruby’s own readme[1], using `v1` is recommended over specific minor versions.

[1] https://github.com/ruby/setup-ruby#versioning