### PR TITLE
Set up slack alerting on failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ EMAIL_ALIASES="
 person@dxw.com, nickname@dxw.com
 other-person@dxw.com, other-nickname@dxw.com
 "
+SLACK_API_TOKEN=xoxb-PUT-REST-OF-TOKEN-IN
+SLACK_NOTIFICATION_CHANNEL="dxw-breathe-productive-sync"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "dotenv"
 gem "memo_wise"
 gem "productive", "0.6.50"
 gem "rake"
+gem "slack-ruby-client"
 
 group :development do
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
+    gli (2.21.0)
+    hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json_api_client (1.5.2)
@@ -77,12 +79,22 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
+    slack-ruby-client (0.14.6)
+      activesupport
+      faraday (>= 0.9)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
     standard (1.12.1)
       rubocop (= 1.29.1)
       rubocop-performance (= 1.13.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   arm64-darwin-20
@@ -98,6 +110,7 @@ DEPENDENCIES
   productive (= 0.6.50)
   rake
   rspec
+  slack-ruby-client
   standard
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ synchronising those different systems.
 Within dxw this project is deployed and run on Heroku. Due to the sensitive
 nature of the data, only a handful of people have access to it.
 
+## Slack Integration
+
+The app will post messages to a slack channel to report if it has encountered
+an error. You will need to type `@Breathe Productive Sync` to add them to a new
+channel.
+
+You might need to get added to the collaborators list if you need to tweak the
+bot's configuration:
+https://app.slack.com/app-settings/T025PM7N0/A04U1KEJFKR/collaborators
+
 ## Manual usage
 
 Normally you should be running this on a schedule eg on Heroku, but in case you

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ synchronising those different systems.
 Within dxw this project is deployed and run on Heroku. Due to the sensitive
 nature of the data, only a handful of people have access to it.
 
-**NOTE** While the GitHub - Heroku integration is broken[1], code merged
-into `main` will not be automatically deployed to Heroku, and one of the people
-with access will have to deploy it manually.
-
-[1] https://blog.heroku.com/github-integration-update
-https://help.heroku.com/UIUA61EH/how-do-i-reconnect-the-github-integration
-
 ## Manual usage
 
 Normally you should be running this on a schedule eg on Heroku, but in case you

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "dotenv"
 Dotenv.load
 
+require "slack-ruby-client"
+
 require_relative "./lib/event/event"
 require_relative "./lib/event/event_collection"
 require_relative "./lib/person/person"
@@ -21,6 +23,15 @@ def email_aliases
     .map { |line| line.strip.split(/\s*[,;]\s*/) }
 end
 
+def notify_slack(message)
+  Slack.configure do |config|
+    config.token = ENV.fetch("SLACK_API_TOKEN")
+  end
+  client = Slack::Web::Client.new
+
+  client.chat_postMessage(channel: ENV.fetch("SLACK_NOTIFICATION_CHANNEL"), text: message, as_user: true)
+end
+
 namespace :productive do
   desc "List all event types on Productive"
   task :list_event_types do
@@ -39,6 +50,7 @@ namespace :breathe do
   task :to_productive, [:earliest_date] do |t, args|
     args.with_defaults(earliest_date: (Date.today - 90).strftime)
 
+    # wrap the whole thing in a try catch to rescue the errors and notify them
     dry_run = to_bool(ENV.fetch("SYNC_DRY_RUN", true))
 
     if dry_run
@@ -75,6 +87,11 @@ namespace :breathe do
     Person
       .all_from_breathe
       .each { |person| person.sync_breathe_to_productive(after: earliest_date) }
+  rescue
+    notify_slack ":alert: There was an error with the Breathe/Productive Sync integration.\n"\
+                 "Repository: https://github.com/dxw/scheduling-event-sync/\n"\
+                 "<!channel>"
+    raise
   end
 
   desc "Obtain the event data from BreatheHR for all or specified employees"


### PR DESCRIPTION
https://trello.com/c/U6Q1lH0t/165-add-more-logging-to-scheduling-event-sync
Needs SLACK_API_TOKEN and SLACK_NOTIFICATION_CHANNEL environment variables setting.

In the event of an exception in the `breathe:to_productive` task, messages will be sent to a slack channel detailing the error. The first is contains the type of error and the second an abbreviated stack trace intended to ignore lines which are in libraries rather than our code.
Slack appears to have a limit on message length somewhere around 3000 characters, so we truncate the stacktrace and separate it from the initial error message.

All setup for slack is done after the initial exception, in the intention that this will not cause any further outages to the sync.

<img width="521" alt="image" src="https://user-images.githubusercontent.com/85497046/226324916-2c19848a-2f64-40ae-9672-d9ecff512904.png">
