### PR TITLE
Use ISO date string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,7 @@ end
 group :test do
   gem "rspec"
 end
+
+group :development, :test do
+  gem "pry"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     ast (2.4.2)
     breathe (0.3.3)
       sawyer (~> 0.8.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
@@ -31,6 +32,7 @@ GEM
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
     memo_wise (1.7.0)
+    method_source (1.0.0)
     minitest (5.18.0)
     multipart-post (2.1.1)
     parallel (1.22.1)
@@ -40,6 +42,9 @@ GEM
       json_api_client (= 1.5.2)
       rack
       request_store (~> 1.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.7)
     rack (3.0.6.1)
     rainbow (3.1.1)
@@ -108,6 +113,7 @@ DEPENDENCIES
   dotenv
   memo_wise
   productive (= 0.6.50)
+  pry
   rake
   rspec
   slack-ruby-client

--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ namespace :breathe do
               "Repository: https://github.com/dxw/scheduling-event-sync/"
     notify_slack slack_client, message
     backtrace = e.backtrace.reject { |x| x.include? "/bundle/ruby/" }
-    notify_slack slack_client, "Abbrieviated stack trace:\n```" + backtrace.join("\n")[0..2975] + "```"
+    notify_slack slack_client, "Abbreviated stack trace:\n```" + backtrace.join("\n")[0..2975] + "```"
     raise
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -59,9 +59,8 @@ end
 namespace :breathe do
   desc "Update all managed events on Productive to match Breathe"
   task :to_productive, [:earliest_date] do |t, args|
-    args.with_defaults(earliest_date: (Date.today - 90).strftime)
+    args.with_defaults(earliest_date: (Date.today - 90).strftime("%F"))
 
-    # wrap the whole thing in a try catch to rescue the errors and notify them
     dry_run = to_bool(ENV.fetch("SYNC_DRY_RUN", true))
 
     if dry_run
@@ -69,8 +68,8 @@ namespace :breathe do
       puts "Temporarily set the environment variable `SYNC_DRY_RUN` to a falsy value to make\nreal changes to Productive"
     end
 
-    earliest_date = Date.parse(args[:earliest_date])
-    puts "Syncing events on or after #{earliest_date.strftime}"
+    earliest_date = Date.parse(args[:earliest_date]).strftime("%F")
+    puts "Syncing events on or after #{earliest_date}"
 
     BreatheClient.configure(
       api_key: ENV.fetch("BREATHE_API_KEY"),
@@ -111,10 +110,10 @@ namespace :breathe do
 
   desc "Obtain the event data from BreatheHR for all or specified employees"
   task :data_dump, [:emails, :earliest_date] do |t, args|
-    args.with_defaults(emails: "", earliest_date: (Date.today - 90).strftime)
+    args.with_defaults(emails: "", earliest_date: (Date.today - 90).strftime("%F"))
 
-    earliest_date = Date.parse(args[:earliest_date])
-    puts "Fetching events on or after #{earliest_date.strftime}"
+    earliest_date = Date.parse(args[:earliest_date]).strftime("%F")
+    puts "Fetching events on or after #{earliest_date}"
 
     emails = args[:emails].split(";").map(&:strip)
 
@@ -173,7 +172,7 @@ namespace :breathe do
       breathe_events = EventCollection.from_array(person_data["events"])
 
       person.sync_breathe_to_productive(
-        after: Date.parse(person_data["earliest_date"]),
+        after: person_data["earliest_date"],
         breathe_events: breathe_events
       )
     end

--- a/lib/event/event_collection_spec.rb
+++ b/lib/event/event_collection_spec.rb
@@ -4,7 +4,7 @@ require_relative "./event_collection"
 
 RSpec.describe EventCollection do
   describe ".from_array" do
-    it "initalises an event collection" do
+    it "initialises an event collection" do
       events_array = [
         {
           "type" => "holiday",

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -32,11 +32,11 @@ class Person
 
   def sync_breathe_to_productive(after:, breathe_events: nil)
     unless fetch_productive_attributes
-      puts "#{label}: no match on Productive"
+      puts "[WARNING] #{label}: no match on Productive"
       return
     end
 
-    puts "#{label}: finding changes"
+    puts "[INFO] #{label}: finding changes"
 
     breathe_events ||= breathe_events(after: after)
     productive_events = productive_events(after: after)
@@ -48,7 +48,7 @@ class Person
 
     ProductiveClient.update_events_for(self, changeset)
 
-    puts "#{label}: done"
+    puts "[INFO] #{label}: done"
   end
 
   def breathe_data(after:)

--- a/lib/person/person.rb
+++ b/lib/person/person.rb
@@ -54,7 +54,7 @@ class Person
   def breathe_data(after:)
     {
       emails: emails,
-      earliest_date: after.strftime("%F"),
+      earliest_date: after,
       events: breathe_events(after: after).as_json
     }
   end

--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -90,7 +90,7 @@ class ProductiveClient
           }
 
         matching_bookings.each { |booking|
-          puts "#{person.label}: remove #{event_ids.key(booking.event.id)} #{booking.started_on.to_date} - #{booking.ended_on.to_date} (#{booking.time.to_f / 60} hours / day)"
+          puts "[INFO] #{person.label}: remove #{event_ids.key(booking.event.id)} #{booking.started_on.to_date} - #{booking.ended_on.to_date} (#{booking.time.to_f / 60} hours / day)"
 
           booking.destroy unless dry_run
         }
@@ -110,16 +110,19 @@ class ProductiveClient
           working_time / 2 :
           working_time
 
-        puts "#{person.label}: create #{event.type} #{event.start_date} - #{event.end_date} (#{time.to_f / 60} hours / day)"
+        puts "[INFO] #{person.label}: create #{event.type} #{event.start_date} - #{event.end_date} (#{time.to_f / 60} hours / day)"
 
         unless dry_run
-          Productive::Booking.create(
+          response = Productive::Booking.create(
             person_id: person.productive_id,
             event_id: event_id,
             started_on: event.start_date,
             ended_on: event.end_date,
             time: time
           )
+          if response.nil? || response.attributes["id"].nil?
+            puts "[ERROR] #{person.label}: Productive booking #{event.type} #{event.start_date} - #{event.end_date} not created"
+          end
         end
       }
     end


### PR DESCRIPTION
- Use ISO date string for the `start_date` parameter
- Add more logging to detect whether a Productive booking creation has failed silently
  I've not made it raise an error to begin with because we don't want it to fail in case Productive isn't behaving predictably. For example, if the response isn't reliable, and is nil or doesn't have an id when the booking has been created.