### PR TITLE
(92) Enable single account sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ argument into the task.
 $ bundle exec rake 'breathe:to_productive[2020-01-01]'
 ```
 
+#### Specifying the accounts to synchronise
+
+By default, the task runs for all the people records in BreatheHR. If you want
+to sync specific people's records, do so by passing an EMAILS environment
+variable to the task, containing the comma-separated emails.
+
+```
+$ bundle exec rake breathe:to_productive EMAILS=someone@dxw.com,sometwo@dxw.com
+```
+
 ## Developing
 
 Running the tests:

--- a/Rakefile
+++ b/Rakefile
@@ -64,12 +64,12 @@ namespace :breathe do
     dry_run = to_bool(ENV.fetch("SYNC_DRY_RUN", true))
 
     if dry_run
-      puts "Doing a dry run!"
-      puts "Temporarily set the environment variable `SYNC_DRY_RUN` to a falsy value to make\nreal changes to Productive"
+      puts "[INFO] Doing a dry run!"
+      puts "[INFO] Temporarily set the environment variable `SYNC_DRY_RUN` to a falsy value to make\nreal changes to Productive"
     end
 
     earliest_date = Date.parse(args[:earliest_date]).strftime("%F")
-    puts "Syncing events on or after #{earliest_date}"
+    puts "[INFO] Syncing events on or after #{earliest_date}"
 
     BreatheClient.configure(
       api_key: ENV.fetch("BREATHE_API_KEY"),


### PR DESCRIPTION
Fixes #92 

By default, the sync task processes all the people records in BreatheHR.
This takes a long time, and it is impractical to run when there are only
a small number of accounts affected by syncronisation issues.

The sync task now looks for an environment variable, `EMAILS`, expected
to contain the comma-separated emails of the records to be processed.