### PR TITLE
Skip events before requested start date

### DIFF
--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -95,14 +95,14 @@ class BreatheClient
           start_date = training[:start_on]&.to_date
 
           if start_date.nil?
-            puts "[DEBUG] Skipping training with nil start_date for #{person.breathe_id}"
+            puts "[DEBUG] #{person.label}: Skipping training with nil start_date"
             next
           end
 
           end_date = training[:end_on]&.to_date
 
           if end_date.nil?
-            puts "[DEBUG] Skipping training with nil end_date for #{person.breathe_id}"
+            puts "[DEBUG] #{person.label}: Skipping training with nil end_date"
             next
           end
 

--- a/lib/breathe_client.rb
+++ b/lib/breathe_client.rb
@@ -43,6 +43,11 @@ class BreatheClient
           half_day_at_start = absence.half_start
           half_day_at_end = absence.half_end
 
+          if end_date < Date.parse(after)
+            puts "[DEBUG] #{person.label}: Skipping absence with end date #{end_date.strftime("%F")} older than the requested earliest date #{after}"
+            next
+          end
+
           Event.new(
             type: type,
             start_date: start_date,
@@ -64,6 +69,11 @@ class BreatheClient
           end_date = sickness[:end_date]&.to_date || Date.today
           half_day_at_start = sickness[:half_start]
           half_day_at_end = sickness[:half_end]
+
+          if end_date < Date.parse(after)
+            puts "[DEBUG] #{person.label}: Skipping sickness with end date #{end_date.strftime("%F")} older than the requested earliest date #{after}"
+            next
+          end
 
           Event.new(
             type: :sickness,
@@ -93,6 +103,11 @@ class BreatheClient
 
           if end_date.nil?
             puts "[DEBUG] Skipping training with nil end_date for #{person.breathe_id}"
+            next
+          end
+
+          if end_date < Date.parse(after)
+            puts "[DEBUG] #{person.label}: Skipping training with end date #{end_date.strftime("%F")} older than the requested earliest date #{after}"
             next
           end
 


### PR DESCRIPTION
Some absences, most often "other leave" absences, are being fetched from
BreatheHR regardless of the earliest date requested. These events are
then duplicated into Productive with every script run.

In the absence of a developer-friendly way to query and investigate the
API, I'm adding some manual checks to prevent more duplicate events from
being created.