### PR TITLE
Use person ID when searching for bookings to remove

### DIFF
--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -79,6 +79,7 @@ class ProductiveClient
 
         matching_bookings = Productive::Booking
           .where(
+            person_id: person.productive_id,
             event_id: event_id,
             after: event.start_date,
             before: event.end_date


### PR DESCRIPTION
# Context

We've had an issue where syncing one person removes events for someone else ([this for example](https://dxw.slack.com/archives/C03JP2BS2SH/p1683631773316189)).

I think this is because we were matching based on event type and dates, not based on person, so if two people had holiday on the same day, we would incorrectly remove both when processing either one of them.

# This PR
This PR adds an additional check to make sure the event belongs to the person being processed.