### PR TITLE
Replace Slack with Rollbar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,6 @@ EMAIL_ALIASES="
 person@dxw.com, nickname@dxw.com
 other-person@dxw.com, other-nickname@dxw.com
 "
-SLACK_API_TOKEN=xoxb-PUT-REST-OF-TOKEN-IN
-SLACK_NOTIFICATION_CHANNEL="dxw-breathe-productive-sync"
+
+ROLLBAR_ACCESS_TOKEN=
+ROLLBAR_ENVIRONMENT= # production | staging | development

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "dotenv"
 gem "memo_wise"
 gem "productive", "0.6.73"
 gem "rake"
-gem "slack-ruby-client"
+gem "rollbar"
 
 group :development do
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,6 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    gli (2.21.1)
-    hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -79,6 +77,7 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.6)
+    rollbar (3.4.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -113,12 +112,6 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    slack-ruby-client (1.0.0)
-      faraday (>= 1.0)
-      faraday_middleware
-      gli
-      hashie
-      websocket-driver
     standard (1.32.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -134,9 +127,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    websocket-driver (0.7.6)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
 
 PLATFORMS
   arm64-darwin-20
@@ -153,8 +143,8 @@ DEPENDENCIES
   productive (= 0.6.73)
   pry
   rake
+  rollbar
   rspec
-  slack-ruby-client
   standard
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@ synchronising those different systems.
 Within dxw this project is deployed and run on Heroku. Due to the sensitive
 nature of the data, only a handful of people have access to it.
 
-## Slack Integration
-
-The app will post messages to a slack channel to report if it has encountered
-an error. You will need to type `@Breathe Productive Sync` to add them to a new
-channel.
-
-You might need to get added to the collaborators list if you need to tweak the
-bot's configuration:
-https://app.slack.com/app-settings/T025PM7N0/A04U1KEJFKR/collaborators
-
 ## Manual usage
 
 Normally you should be running this on a schedule eg on Heroku, but in case you


### PR DESCRIPTION
# Context

Currently we use a Slack integration to post error messages to Slack. This is unusual for our projects, as we normally use Rollbar which requires less configuration.

# This PR

This PR replaces the Slack integration with Rollbar, bringing this project in line with our standard approach.

# Note

If we merge this PR we will also need to delete the Slack app: https://api.slack.com/apps/A04U1KEJFKR/general