### PR TITLE
Explicitly include event data

### DIFF
--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -144,6 +144,7 @@ class ProductiveClient
           event_id: event_ids.values,
           after: after
         )
+        .includes(:event)
         .all
     end
     memo_wise :bookings


### PR DESCRIPTION
# Context
Productive made a breaking change to its API on 1st August such that responses no longer return included data by default.

This means that the event for a booking is not included and our script fails.

# This PR

This PR updates the request to Productive to explicitly include the event data.