### PR TITLE
Return only active Productive Users

### DIFF
--- a/lib/productive_client.rb
+++ b/lib/productive_client.rb
@@ -130,7 +130,8 @@ class ProductiveClient
     end
 
     def person(emails:)
-      Productive::Person.where(email: emails).first
+      # Status 1 is active
+      Productive::Person.where(email: emails, status: 1).first
     end
     memo_wise :person
 


### PR DESCRIPTION
# Context
Some staff have multiple accounts on Productive, only one of which is active. This causes problems when attempting to match based on email address or alias because the wrong user is returned (such as https://app.productive.io/15642-dxw/person/172735/info).

# This PR
This PR fixes the problem but adding a status filter so that the request to Productive only returns active users.